### PR TITLE
Enh: Four Finger & Smeared Joker hands

### DIFF
--- a/keyboard_dorkdad.lua
+++ b/keyboard_dorkdad.lua
@@ -485,23 +485,27 @@ function best_flush_suit()
 end
 
 function sorted_cards_by_suit(...)
+    local args = { ... }
+    -- Additionally, include any wild cards in hand
+    local suits = { Wild = true }
+    for _, suit in pairs(args) do
+        suits[suit] = true
+    end
+
     local cards = {}
-    local count = 0
-    local suits = { ... }
-    for _, suit in pairs(suits) do
-        for i = 1, #G.hand.cards do
-            card = G.hand.cards[i]
-            if get_visible_suit(card) == suit or get_visible_suit(card) == "Wild" then
-                table.insert(cards, card)
-                count = count + 1
-            end
+    for i = 1, #G.hand.cards do
+        local card = G.hand.cards[i]
+        if suits[get_visible_suit(card)] then
+            table.insert(cards, card)
         end
     end
+
     table.sort(cards, function(x, y)
         return calculate_importance(x, true) > calculate_importance(y, true)
     end)
     return cards
 end
+
 
 function flush(suit)
     G.hand:unhighlight_all()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5e63ceb3-0a86-49f4-834c-482e18e3abf3)


This PR extends support for a _handful_ of special flushes/straights enabled by [`Four Fingers`](https://balatrogame.fandom.com/wiki/Four_Fingers_(Joker)) & [`Smeared Joker`](https://balatrogame.fandom.com/wiki/Smeared_Joker_(Joker))

Specifically it:
1. will check flushes of size 4 if the player is four-fingered
2. as well as straights
3. if they are smeared, combined suits are sourced when scoring potential flush hands both when using `[B]est` as well as the specific suit hotkeys
3. `[F]` / `best_flush_suit()` will also prioritize the better rated of the two suits if smeared

While I did see your note about selection code largely originating from another project, I assumed it unlikely that upstream changes would wind up here. There seem to be a few new refactoring changes within that project, but the TODO comment about adding joker interactions is still there.