### PR TITLE
fix: cash out button can be triggered while it's despawning

### DIFF
--- a/keyboard_dorkdad.lua
+++ b/keyboard_dorkdad.lua
@@ -68,7 +68,7 @@ function Controller.key_press_update(self, key, dt)
             local cash_out_button
             for e, _ in pairs(G.ORPHANED_UIBOXES) do
                 cash_out_button = e:get_UIE_by_ID("cash_out_button")
-                if cash_out_button then
+                if cash_out_button and cash_out_button.config.button then
                     G.FUNCS.cash_out(cash_out_button)
                     return
                 end


### PR DESCRIPTION
i realised i can cash out twice or 3 times while the button is getting removed from view due to animation delays, so i added a second check for `cash_out_button.config.button` which immediately gets set to `nil` by `G.FUNCS.cash_out`, so a user with a keyboard can't outpace it